### PR TITLE
Added hours, minutes, and seconds time printout

### DIFF
--- a/lib/game_renderer.py
+++ b/lib/game_renderer.py
@@ -46,7 +46,11 @@ class GameRenderer(object):
 
     def _display_finish_time(self, start_time):
         time_diff = time.time() - start_time
-        print(f'\n\nFinished in {time_diff} seconds')
+        hours, minutes, seconds = self._split_time_from_diff(time_diff)
+        print(f'\n\nFinished in {hours} hours, {minutes} minutes, and {seconds} seconds')
+
+    def _split_time_from_diff(self, time_diff):
+        return int(time_diff / 3600), int((time_diff % 3600) / 60), int((time_diff % 3600) % 60)
 
     def _display_board(self, show_mines=False):
         position = 0


### PR DESCRIPTION
# What/Why

I wanted a cleaner printout of how long it took. So I decided to split it up between hours, minutes and seconds.

Old output:
```
Finished in 3789.986104488373 seconds
```

New output:
```
Finished in 1 hours, 2 minutes, and 9 seconds
```

**Note:** I rounded down completely so even though it was 9.986 seconds, it will still only show 9 as I called `int()` on that value. I suppose I could use `round()` instead, but I would rather just leave it as is and call this the functionality that I want.